### PR TITLE
XRechnung validator on CI

### DIFF
--- a/.github/workflows/xrechnung_validator.yaml
+++ b/.github/workflows/xrechnung_validator.yaml
@@ -1,0 +1,57 @@
+name: XRechnung Validator
+on:
+  workflow_dispatch:
+    inputs:
+      file:
+        default: './test/data/out/01.01a-INVOICE_uncefact.xml'
+        description: 'XML file to validation'
+        required: true
+      validator_version:
+        default: '1.5.0'
+        description: 'KoSIT Validator version'
+        options:
+          - '1.5.0'
+        required: true
+        type: choice
+
+jobs:
+  validation_tool:
+    env:
+      INPUT_FILE: ${{ inputs.file }}
+      VALIDATOR_VERSION: ${{ inputs.validator_version }}
+      VALIDATOR_JAR_FILE: "validationtool-${{ inputs.validator_version }}-standalone.jar"
+    name: Validation tool
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Check if the input file exists
+        run: |
+          if [[ -f "$INPUT_FILE" ]]; then
+            echo "$INPUT_FILE exists."
+          else
+            echo "$INPUT_FILE does not exist."
+            exit 1
+          fi
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - name: Download validator
+        run: curl -L "https://github.com/itplr-kosit/validator/releases/download/v$VALIDATOR_VERSION/validator-$VALIDATOR_VERSION-distribution.zip" --output validator.zip
+      - name: Download configuration
+        run: curl -L "https://github.com/itplr-kosit/validator-configuration-xrechnung/releases/download/release-2023-11-15/validator-configuration-xrechnung_3.0.1_2023-11-15.zip" --output validator-configuration.zip
+      - name: Unzip validator
+        run: unzip -n validator.zip "$VALIDATOR_JAR_FILE"
+      - name: Unzip configuration
+        run: unzip -n validator-configuration.zip
+      - name: Run Validator
+        id: validator
+        run: java -jar "$VALIDATOR_JAR_FILE" -s scenarios.xml -r "${PWD}" -h "$INPUT_FILE"
+      - name: Upload report if failed
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: report
+          path: "*-report*"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # gobl.xinvoice
+
 GOBL conversion into Factur-X (FR) and XRechnung/ZUGFeRD (DE) formats.
 
 ## Development


### PR DESCRIPTION
## Pull Request Summary

I introduced **XRechnung** validation workflow using GitHub Actions. It allows manual triggering via workflow_dispatch, enabling us to specify the XML file for validation. In case of failure, reports are provided as artifacts for easy analysis.

## Feedback

This is an internal tool and there is no point in including it in a package in Go. There is also no Go version of the validator for Schematron. Therefore, running in the CI process seems to be the most reasonable solution.

The validator and its configuration allow us to check the following scenarios:

```
Loaded "Validator Configuration XRechnung 3.0.1" by Coordination Office for IT Standards (KoSIT) from 2023-11-14 
The following scenarios are available:
  * EN[16] XRechnung (UBL Invoice)
  * EN16931 XRechnung Extension (UBL Invoice)
  * EN16931 XRechnung (UBL CreditNote)
  * EN16931 XRechnung (CII)
  * EN16931 XRechnung Extension (CII)
  * EN16931 (UBL Invoice)
  * EN16931 (UBL CreditNote)
  * EN16931 (CII)
```

## How to use it

![Screenshot](https://github.com/invopop/gobl.xinvoice/assets/76075/497a22fc-c442-42f2-8642-28621f51e71b)
