### PR TITLE
Improve code and test readability for XRechnung

### DIFF
--- a/agreement.go
+++ b/agreement.go
@@ -7,6 +7,9 @@ import (
 	"github.com/invopop/gobl/org"
 )
 
+// SchemeIDEmail represents the Scheme ID for email addresses
+const SchemeIDEmail = "EM"
+
 // Agreement defines the structure of the ApplicableHeaderTradeAgreement of the CII standard
 type Agreement struct {
 	BuyerReference string  `xml:"ram:BuyerReference"`
@@ -75,7 +78,7 @@ func NewEmail(emails []*org.Email) *URIUniversalCommunication {
 
 	email := &URIUniversalCommunication{
 		URIID:    emails[0].Address,
-		SchemeID: "EM",
+		SchemeID: SchemeIDEmail,
 	}
 
 	return email

--- a/buyer_test.go
+++ b/buyer_test.go
@@ -3,6 +3,7 @@ package xinvoice_test
 import (
 	"testing"
 
+	xinvoice "github.com/invopop/gobl.xinvoice"
 	"github.com/invopop/gobl.xinvoice/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func TestNewBuyer(t *testing.T) {
 		assert.Equal(t, "München", doc.Transaction.Agreement.Buyer.PostalTradeAddress.City)
 		assert.Equal(t, "DE", doc.Transaction.Agreement.Buyer.PostalTradeAddress.CountryID)
 		assert.Equal(t, "email@sample.com", doc.Transaction.Agreement.Buyer.URIUniversalCommunication.URIID)
-		assert.Equal(t, "EM", doc.Transaction.Agreement.Buyer.URIUniversalCommunication.SchemeID)
+		assert.Equal(t, xinvoice.SchemeIDEmail, doc.Transaction.Agreement.Buyer.URIUniversalCommunication.SchemeID)
 	})
 
 	t.Run("should contain the buyer info from simplified invoice", func(t *testing.T) {
@@ -36,6 +37,6 @@ func TestNewBuyer(t *testing.T) {
 		assert.Equal(t, "München", doc.Transaction.Agreement.Buyer.PostalTradeAddress.City)
 		assert.Equal(t, "DE", doc.Transaction.Agreement.Buyer.PostalTradeAddress.CountryID)
 		assert.Equal(t, "email@sample.com", doc.Transaction.Agreement.Buyer.URIUniversalCommunication.URIID)
-		assert.Equal(t, "EM", doc.Transaction.Agreement.Buyer.URIUniversalCommunication.SchemeID)
+		assert.Equal(t, xinvoice.SchemeIDEmail, doc.Transaction.Agreement.Buyer.URIUniversalCommunication.SchemeID)
 	})
 }

--- a/header.go
+++ b/header.go
@@ -7,6 +7,9 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// IssueDateFormat is the issue date format in the form YYYYMMDD
+const IssueDateFormat = "102"
+
 // Header a collection of data for a Cross Industry Invoice Header that is exchanged between two or more parties in written, printed or electronic form.
 type Header struct {
 	ID           string `xml:"ram:ID"`
@@ -28,7 +31,7 @@ func NewHeader(inv *bill.Invoice) *Header {
 		TypeCode: invoiceTypeCode(inv),
 		IssueDate: &Date{
 			Date:   formatIssueDate(inv.IssueDate),
-			Format: "102",
+			Format: IssueDateFormat,
 		},
 	}
 }

--- a/header_test.go
+++ b/header_test.go
@@ -18,7 +18,7 @@ func TestNewHeader(t *testing.T) {
 		assert.Equal(t, "SAMPLE-001", doc.ExchangedDocument.ID)
 		assert.Equal(t, "380", doc.ExchangedDocument.TypeCode)
 		assert.Equal(t, "20240213", doc.ExchangedDocument.IssueDate.Date)
-		assert.Equal(t, "102", doc.ExchangedDocument.IssueDate.Format)
+		assert.Equal(t, xinvoice.IssueDateFormat, doc.ExchangedDocument.IssueDate.Format)
 	})
 
 	t.Run("should contain the header info from credit note", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestNewHeader(t *testing.T) {
 		assert.Equal(t, "CN-002", doc.ExchangedDocument.ID)
 		assert.Equal(t, "381", doc.ExchangedDocument.TypeCode)
 		assert.Equal(t, "20240214", doc.ExchangedDocument.IssueDate.Date)
-		assert.Equal(t, "102", doc.ExchangedDocument.IssueDate.Format)
+		assert.Equal(t, xinvoice.IssueDateFormat, doc.ExchangedDocument.IssueDate.Format)
 	})
 
 	t.Run("should return self billed type code for self billed invoice", func(t *testing.T) {

--- a/line.go
+++ b/line.go
@@ -60,16 +60,6 @@ func newTradeSettlement(line *bill.Line) *TradeSettlement {
 		taxCode := FindTaxCode(line)
 		tradeTax := &ApplicableTradeTax{
 			TaxType: tax.Category.String(),
-			// The sales tax category codes are as follows:
-			// - S = Sales tax applies at the standard rate
-			// - Z = goods taxable at the zero rate
-			// - E = Tax exempt
-			// - AE = Reversal of tax liability
-			// - K = No sales tax is shown for intra-community deliveries
-			// - G = Tax not charged due to export outside the EU
-			// - O = Outside the tax scope
-			// - L = IGIC (Canary Islands)
-			// - M = IPSI (Ceuta/Melilla)
 			TaxCode: taxCode,
 		}
 

--- a/line.go
+++ b/line.go
@@ -57,6 +57,7 @@ func newLine(line *bill.Line) *Line {
 func newTradeSettlement(line *bill.Line) *TradeSettlement {
 	var applicableTradeTax []*ApplicableTradeTax
 	for _, tax := range line.Taxes {
+		taxCode := FindTaxCode(line)
 		tradeTax := &ApplicableTradeTax{
 			TaxType: tax.Category.String(),
 			// The sales tax category codes are as follows:
@@ -69,7 +70,7 @@ func newTradeSettlement(line *bill.Line) *TradeSettlement {
 			// - O = Outside the tax scope
 			// - L = IGIC (Canary Islands)
 			// - M = IPSI (Ceuta/Melilla)
-			TaxCode: "S",
+			TaxCode: taxCode,
 		}
 
 		if tax.Percent != nil {

--- a/line_test.go
+++ b/line_test.go
@@ -3,6 +3,7 @@ package xinvoice_test
 import (
 	"testing"
 
+	xinvoice "github.com/invopop/gobl.xinvoice"
 	"github.com/invopop/gobl.xinvoice/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func TestNewLines(t *testing.T) {
 		assert.Equal(t, "20", doc.Transaction.Lines[0].TradeDelivery.Amount)
 		assert.Equal(t, "HUR", doc.Transaction.Lines[0].TradeDelivery.UnitCode)
 		assert.Equal(t, "VAT", doc.Transaction.Lines[0].TradeSettlement.ApplicableTradeTax[0].TaxType)
-		assert.Equal(t, "S", doc.Transaction.Lines[0].TradeSettlement.ApplicableTradeTax[0].TaxCode)
+		assert.Equal(t, xinvoice.StandardSalesTax, doc.Transaction.Lines[0].TradeSettlement.ApplicableTradeTax[0].TaxCode)
 		assert.Equal(t, "19", doc.Transaction.Lines[0].TradeSettlement.ApplicableTradeTax[0].TaxRatePercent)
 		assert.Equal(t, "1800.00", doc.Transaction.Lines[0].TradeSettlement.Sum)
 	})

--- a/seller.go
+++ b/seller.go
@@ -37,6 +37,9 @@ type Contact struct {
 
 // NewSeller creates the SellerTradeParty part of a EN 16931 compliant invoice
 func NewSeller(supplier *org.Party) *Seller {
+	if supplier == nil {
+		return nil
+	}
 	seller := &Seller{
 		Name:                      supplier.Name,
 		Contact:                   newContact(supplier),

--- a/seller_test.go
+++ b/seller_test.go
@@ -3,6 +3,7 @@ package xinvoice_test
 import (
 	"testing"
 
+	xinvoice "github.com/invopop/gobl.xinvoice"
 	"github.com/invopop/gobl.xinvoice/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,6 @@ func TestNewSeller(t *testing.T) {
 		assert.Equal(t, "Walldorf", doc.Transaction.Agreement.Seller.PostalTradeAddress.City)
 		assert.Equal(t, "DE", doc.Transaction.Agreement.Seller.PostalTradeAddress.CountryID)
 		assert.Equal(t, "billing@example.com", doc.Transaction.Agreement.Seller.URIUniversalCommunication.URIID)
-		assert.Equal(t, "EM", doc.Transaction.Agreement.Seller.URIUniversalCommunication.SchemeID)
+		assert.Equal(t, xinvoice.SchemeIDEmail, doc.Transaction.Agreement.Seller.URIUniversalCommunication.SchemeID)
 	})
 }

--- a/settlement.go
+++ b/settlement.go
@@ -48,9 +48,13 @@ type TaxTotalAmount struct {
 
 // NewSettlement creates the ApplicableHeaderTradeSettlement part of a EN 16931 compliant invoice
 func NewSettlement(inv *bill.Invoice) *Settlement {
+	typeCode := TypeCodeInstrumentNotDefined
+	if !isValidTypeCode(typeCode) {
+		return nil
+	}
 	settlement := &Settlement{
 		Currency:    string(inv.Currency),
-		TypeCode:    "1",
+		TypeCode:    typeCode,
 		Description: inv.Payment.Terms.Detail,
 	}
 

--- a/settlement.go
+++ b/settlement.go
@@ -48,13 +48,9 @@ type TaxTotalAmount struct {
 
 // NewSettlement creates the ApplicableHeaderTradeSettlement part of a EN 16931 compliant invoice
 func NewSettlement(inv *bill.Invoice) *Settlement {
-	typeCode := TypeCodeInstrumentNotDefined
-	if !isValidTypeCode(typeCode) {
-		return nil
-	}
 	settlement := &Settlement{
 		Currency:    string(inv.Currency),
-		TypeCode:    typeCode,
+		TypeCode:    FindTypeCode(inv),
 		Description: inv.Payment.Terms.Detail,
 	}
 

--- a/settlement_test.go
+++ b/settlement_test.go
@@ -16,7 +16,7 @@ func TestNewSettlement(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, "EUR", doc.Transaction.Settlement.Currency)
-		assert.Equal(t, "1", doc.Transaction.Settlement.TypeCode)
+		assert.Equal(t, xinvoice.TypeCodeInstrumentNotDefined, doc.Transaction.Settlement.TypeCode)
 		assert.Equal(t, "lorem ipsum", doc.Transaction.Settlement.Description)
 		assert.Equal(t, "1800.00", doc.Transaction.Settlement.Summary.TotalAmount)
 		assert.Equal(t, "1800.00", doc.Transaction.Settlement.Summary.TaxBasisTotalAmount)

--- a/tax_code.go
+++ b/tax_code.go
@@ -1,0 +1,55 @@
+package xinvoice
+
+import "github.com/invopop/gobl/bill"
+
+// StandardSalesTax is the tax type for sales tax applying at the standard rate
+const StandardSalesTax = "S"
+
+// ZeroRatedGoodsTax is the tax type for goods taxable at the zero rate
+const ZeroRatedGoodsTax = "Z"
+
+// TaxExempt indicates the tax type for exempt transactions
+const TaxExempt = "E"
+
+// ReverseCharge indicates the tax type for reverse charge transactions
+const ReverseCharge = "AE"
+
+// NoSalesTaxIntraCommunity indicates no sales tax is shown for intra-community deliveries
+const NoSalesTaxIntraCommunity = "K"
+
+// TaxNotChargedExportOutsideEU indicates tax is not charged due to export outside the EU
+const TaxNotChargedExportOutsideEU = "G"
+
+// OutOfTaxScope indicates transactions outside the tax scope
+const OutOfTaxScope = "O"
+
+// IGIC represents IGIC (Canary Islands)
+const IGIC = "L"
+
+// IPSI represents IPSI (Ceuta/Melilla)
+const IPSI = "M"
+
+// FindTaxCode finds the tax code for the provided bill line.
+// It returns the found tax code.
+func FindTaxCode(line *bill.Line) string {
+	if len(line.Taxes) == 0 {
+		return StandardSalesTax
+	}
+	tax := line.Taxes[0]
+
+	switch tax.Rate {
+	case "standard":
+		return StandardSalesTax
+	case "zero":
+		return ZeroRatedGoodsTax
+	}
+
+	switch tax.Category {
+	case "IGIC":
+		return IGIC
+	case "IPSI":
+		return IPSI
+	}
+
+	return StandardSalesTax
+}

--- a/tax_code.go
+++ b/tax_code.go
@@ -1,6 +1,9 @@
 package xinvoice
 
-import "github.com/invopop/gobl/bill"
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/tax"
+)
 
 const (
 	// StandardSalesTax is the tax type for sales tax applying at the standard rate
@@ -48,16 +51,18 @@ func FindTaxCode(line *bill.Line) string {
 	if len(line.Taxes) == 0 {
 		return StandardSalesTax
 	}
-	tax := line.Taxes[0]
+	t := line.Taxes[0]
 
-	switch tax.Rate {
-	case "standard":
+	switch t.Rate {
+	case tax.RateStandard:
 		return StandardSalesTax
-	case "zero":
+	case tax.RateZero:
 		return ZeroRatedGoodsTax
+	case tax.RateExempt:
+		return TaxExempt
 	}
 
-	switch tax.Category {
+	switch t.Category {
 	case "IGIC":
 		return IGIC
 	case "IPSI":

--- a/tax_code.go
+++ b/tax_code.go
@@ -2,35 +2,48 @@ package xinvoice
 
 import "github.com/invopop/gobl/bill"
 
-// StandardSalesTax is the tax type for sales tax applying at the standard rate
-const StandardSalesTax = "S"
+const (
+	// StandardSalesTax is the tax type for sales tax applying at the standard rate
+	StandardSalesTax = "S"
 
-// ZeroRatedGoodsTax is the tax type for goods taxable at the zero rate
-const ZeroRatedGoodsTax = "Z"
+	// ZeroRatedGoodsTax is the tax type for goods taxable at the zero rate
+	ZeroRatedGoodsTax = "Z"
 
-// TaxExempt indicates the tax type for exempt transactions
-const TaxExempt = "E"
+	// TaxExempt indicates the tax type for exempt transactions
+	TaxExempt = "E"
 
-// ReverseCharge indicates the tax type for reverse charge transactions
-const ReverseCharge = "AE"
+	// ReverseCharge indicates the tax type for reverse charge transactions
+	ReverseCharge = "AE"
 
-// NoSalesTaxIntraCommunity indicates no sales tax is shown for intra-community deliveries
-const NoSalesTaxIntraCommunity = "K"
+	// NoSalesTaxIntraCommunity indicates no sales tax is shown for intra-community deliveries
+	NoSalesTaxIntraCommunity = "K"
 
-// TaxNotChargedExportOutsideEU indicates tax is not charged due to export outside the EU
-const TaxNotChargedExportOutsideEU = "G"
+	// TaxNotChargedExportOutsideEU indicates tax is not charged due to export outside the EU
+	TaxNotChargedExportOutsideEU = "G"
 
-// OutOfTaxScope indicates transactions outside the tax scope
-const OutOfTaxScope = "O"
+	// OutOfTaxScope indicates transactions outside the tax scope
+	OutOfTaxScope = "O"
 
-// IGIC represents IGIC (Canary Islands)
-const IGIC = "L"
+	// IGIC represents IGIC (Canary Islands)
+	IGIC = "L"
 
-// IPSI represents IPSI (Ceuta/Melilla)
-const IPSI = "M"
+	// IPSI represents IPSI (Ceuta/Melilla)
+	IPSI = "M"
+)
 
 // FindTaxCode finds the tax code for the provided bill line.
 // It returns the found tax code.
+//
+// The sales tax category codes are as follows:
+// - S = Sales tax applies at the standard rate
+// - Z = goods taxable at the zero rate
+// - E = Tax exempt
+// - AE = Reversal of tax liability
+// - K = No sales tax is shown for intra-community deliveries
+// - G = Tax not charged due to export outside the EU
+// - O = Outside the tax scope
+// - L = IGIC (Canary Islands)
+// - M = IPSI (Ceuta/Melilla)
 func FindTaxCode(line *bill.Line) string {
 	if len(line.Taxes) == 0 {
 		return StandardSalesTax

--- a/type_code.go
+++ b/type_code.go
@@ -2,6 +2,8 @@ package xinvoice
 
 import (
 	"strconv"
+
+	"github.com/invopop/gobl/bill"
 )
 
 // TypeCodeInstrumentNotDefined is the Type Code for an undefined Payment Instrument
@@ -104,4 +106,17 @@ func isValidTypeCode(code string) bool {
 		return false
 	}
 	return ((num >= 1 && num <= 70) || (num >= 74 && num <= 78) || (num >= 91 && num <= 97))
+}
+
+// FindTypeCode finds the type code for invoice.
+// The default return value is TypeCodeInstrumentNotDefined
+func FindTypeCode(inv *bill.Invoice) string {
+	code := TypeCodeInstrumentNotDefined
+	if inv.Payment == nil || inv.Payment.Instructions == nil {
+		return TypeCodeInstrumentNotDefined
+	}
+	if !isValidTypeCode(code) {
+		return TypeCodeInstrumentNotDefined
+	}
+	return TypeCodeInstrumentNotDefined
 }

--- a/type_code.go
+++ b/type_code.go
@@ -1,0 +1,107 @@
+package xinvoice
+
+import (
+	"strconv"
+)
+
+// TypeCodeInstrumentNotDefined is the Type Code for an undefined Payment Instrument
+const TypeCodeInstrumentNotDefined = "1"
+
+// Acceptable codes:
+// 1   - Instrument not defined
+// 2   - Automated clearing house credit
+// 3   - Automated clearing house debit
+// 4   - ACH demand debit reversal
+// 5   - ACH demand credit reversal
+// 6   - ACH demand credit
+// 7   - ACH demand debit
+// 8   - Hold
+// 9   - National or regional clearing
+// 10  - In cash
+// 11  - ACH savings credit reversal
+// 12  - ACH savings debit reversal
+// 13  - ACH savings credit
+// 14  - ACH savings debit
+// 15  - Bookentry credit
+// 16  - Bookentry debit
+// 17  - ACH demand cash concentration/disbursement (CCD) credit
+// 18  - ACH demand cash concentration/disbursement (CCD) debit
+// 19  - ACH demand corporate trade payment (CTP) credit
+// 20  - Cheque
+// 21  - Banker's draft
+// 22  - Certified banker's draft
+// 23  - Bank cheque (issued by a banking or similar establishment)
+// 24  - Bill of exchange awaiting acceptance
+// 25  - Certified cheque
+// 26  - Local cheque
+// 27  - ACH demand corporate trade payment (CTP) debit
+// 28  - ACH demand corporate trade exchange (CTX) credit
+// 29  - ACH demand corporate trade exchange (CTX) debit
+// 30  - Credit transfer
+// 31  - Debit transfer
+// 32  - ACH demand cash concentration/disbursement plus (CCD+) credit
+// 33  - ACH demand cash concentration/disbursement plus (CCD+) debit
+// 34  - ACH prearranged payment and deposit (PPD)
+// 35  - ACH savings cash concentration/disbursement (CCD) credit
+// 36  - ACH savings cash concentration/disbursement (CCD) debit
+// 37  - ACH savings corporate trade payment (CTP) credit
+// 38  - ACH savings corporate trade payment (CTP) debit
+// 39  - ACH savings corporate trade exchange (CTX) credit
+// 40  - ACH savings corporate trade exchange (CTX) debit
+// 41  - ACH savings cash concentration/disbursement plus (CCD+) credit
+// 42  - Payment to bank account
+// 43  - ACH savings cash concentration/disbursement plus (CCD+) debit
+// 44  - Accepted bill of exchange
+// 45  - Referenced home-banking credit transfer
+// 46  - Interbank debit transfer
+// 47  - Home-banking debit transfer
+// 48  - Bank card
+// 49  - Direct debit
+// 50  - Payment by postgiro
+// 51  - FR, norme 6 97-Telereglement CFONB (French Organisation for Banking Standards)  - Option A
+// 52  - Urgent commercial payment
+// 53  - Urgent Treasury Payment
+// 54  - Credit card
+// 55  - Debit card
+// 56  - Bankgiro
+// 57  - Standing agreement
+// 58  - SEPA credit transfer
+// 59  - SEPA direct debit
+// 60  - Promissory note
+// 61  - Promissory note signed by the debtor
+// 62  - Promissory note signed by the debtor and endorsed by a bank
+// 63  - Promissory note signed by the debtor and endorsed by a third party
+// 64  - Promissory note signed by a bank
+// 65  - Promissory note signed by a bank and endorsed by another bank
+// 66  - Promissory note signed by a third party
+// 67  - Promissory note signed by a third party and endorsed by a bank
+// 68  - Online payment service
+// 69  - Transfer Advice
+// 70  - Bill drawn by the creditor on the debtor
+// 74  - Bill drawn by the creditor on a bank
+// 75  - Bill drawn by the creditor, endorsed by another bank
+// 76  - Bill drawn by the creditor on a bank and endorsed by a third party
+// 77  - Bill drawn by the creditor on a third party
+// 78  - Bill drawn by creditor on third party, accepted and endorsed by bank
+// 91  - Not transferable banker's draft
+// 92  - Not transferable local cheque
+// 93  - Reference giro
+// 94  - Urgent giro
+// 95  - Free format giro
+// 96  - Requested method for payment was not used
+// 97  - Clearing between partners
+// ZZZ - Mutually defined
+//
+// source of information:
+// https://portal3.gefeg.com/projectdata/invoice/deliverables/installed/publishingproject/xrechnung%202.2.0%20-%20(ab%2001.08.2022)/xrechnung_cii_v2.2.0_01.08.2022.scm/html/DE/02216.htm
+func isValidTypeCode(code string) bool {
+	if code == "ZZZ" {
+		return true
+	}
+
+	num, err := strconv.Atoi(code)
+	if err != nil {
+		return false
+	}
+	return ((num >= 1 && num <= 70) || (num >= 74 && num <= 78) || (num >= 91 && num <= 97))
+}


### PR DESCRIPTION
## Pull Request Summary

I introduced some constants and some logic associated with it.

Resolve #8 

## Feedback

Please note that TypeCode cannot be a number because the string "ZZZ" is acceptable.

I know that the `FindTaxCode` function has many more cases to consider. However, this is a good starting point.