### PR TITLE
Cleanup tax categories

### DIFF
--- a/line.go
+++ b/line.go
@@ -57,10 +57,9 @@ func newLine(line *bill.Line) *Line {
 func newTradeSettlement(line *bill.Line) *TradeSettlement {
 	var applicableTradeTax []*ApplicableTradeTax
 	for _, tax := range line.Taxes {
-		taxCode := FindTaxCode(line)
 		tradeTax := &ApplicableTradeTax{
 			TaxType: tax.Category.String(),
-			TaxCode: taxCode,
+			TaxCode: FindTaxCode(tax.Rate, tax.Category),
 		}
 
 		if tax.Percent != nil {

--- a/line.go
+++ b/line.go
@@ -59,7 +59,7 @@ func newTradeSettlement(line *bill.Line) *TradeSettlement {
 	for _, tax := range line.Taxes {
 		tradeTax := &ApplicableTradeTax{
 			TaxType: tax.Category.String(),
-			TaxCode: FindTaxCode(tax.Rate, tax.Category),
+			TaxCode: FindTaxCode(tax.Rate),
 		}
 
 		if tax.Percent != nil {

--- a/settlement.go
+++ b/settlement.go
@@ -112,7 +112,7 @@ func newTax(rate *tax.RateTotal, category *tax.CategoryTotal) *Tax {
 		CalculatedAmount:      rate.Amount.String(),
 		TypeCode:              category.Code.String(),
 		BasisAmount:           rate.Base.String(),
-		CategoryCode:          FindTaxCode(rate.Key, category.Code),
+		CategoryCode:          FindTaxCode(rate.Key),
 		RateApplicablePercent: rate.Percent.StringWithoutSymbol(),
 	}
 

--- a/settlement.go
+++ b/settlement.go
@@ -2,7 +2,6 @@ package xinvoice
 
 import (
 	"github.com/invopop/gobl/bill"
-	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/tax"
 )
 
@@ -113,28 +112,9 @@ func newTax(rate *tax.RateTotal, category *tax.CategoryTotal) *Tax {
 		CalculatedAmount:      rate.Amount.String(),
 		TypeCode:              category.Code.String(),
 		BasisAmount:           rate.Base.String(),
-		CategoryCode:          taxCategoryCode(rate.Key),
+		CategoryCode:          FindTaxCode(rate.Key, category.Code),
 		RateApplicablePercent: rate.Percent.StringWithoutSymbol(),
 	}
 
 	return tax
-}
-
-// AE - VAT Reverse Charge
-// E  - Exempt from tax
-// G  - Free export item, tax not charged
-// K  - VAT exempt for EEA intra-community supply of goods and services
-// L  - Canary Islands general indirect tax
-// M  - Tax for production, services and importation in Ceuta and Melilla
-// O  - Services outside scope of tax
-// S  - Standard rate
-// Z  - Zero rated goods
-func taxCategoryCode(key cbc.Key) string {
-	hash := map[cbc.Key]string{
-		tax.RateStandard: "S",
-		tax.RateReduced:  "S",
-		tax.RateZero:     "Z",
-	}
-
-	return hash[key]
 }

--- a/tax_code.go
+++ b/tax_code.go
@@ -47,7 +47,7 @@ const (
 // - O = Outside the tax scope
 // - L = IGIC (Canary Islands)
 // - M = IPSI (Ceuta/Melilla)
-func FindTaxCode(taxRate cbc.Key, taxCategory cbc.Code) string {
+func FindTaxCode(taxRate cbc.Key) string {
 	switch taxRate {
 	case tax.RateStandard:
 		return StandardSalesTax
@@ -55,13 +55,6 @@ func FindTaxCode(taxRate cbc.Key, taxCategory cbc.Code) string {
 		return ZeroRatedGoodsTax
 	case tax.RateExempt:
 		return TaxExempt
-	}
-
-	switch taxCategory {
-	case "IGIC":
-		return IGIC
-	case "IPSI":
-		return IPSI
 	}
 
 	return StandardSalesTax

--- a/tax_code.go
+++ b/tax_code.go
@@ -1,7 +1,7 @@
 package xinvoice
 
 import (
-	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/tax"
 )
 
@@ -47,13 +47,8 @@ const (
 // - O = Outside the tax scope
 // - L = IGIC (Canary Islands)
 // - M = IPSI (Ceuta/Melilla)
-func FindTaxCode(line *bill.Line) string {
-	if len(line.Taxes) == 0 {
-		return StandardSalesTax
-	}
-	t := line.Taxes[0]
-
-	switch t.Rate {
+func FindTaxCode(taxRate cbc.Key, taxCategory cbc.Code) string {
+	switch taxRate {
 	case tax.RateStandard:
 		return StandardSalesTax
 	case tax.RateZero:
@@ -62,7 +57,7 @@ func FindTaxCode(line *bill.Line) string {
 		return TaxExempt
 	}
 
-	switch t.Category {
+	switch taxCategory {
 	case "IGIC":
 		return IGIC
 	case "IPSI":

--- a/tax_code_test.go
+++ b/tax_code_test.go
@@ -1,0 +1,29 @@
+package xinvoice_test
+
+import (
+	"testing"
+
+	xinvoice "github.com/invopop/gobl.xinvoice"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindTaxCode(t *testing.T) {
+	t.Run("should return correct tax category", func(t *testing.T) {
+		taxCode := xinvoice.FindTaxCode(tax.RateStandard)
+
+		assert.Equal(t, xinvoice.StandardSalesTax, taxCode)
+	})
+
+	t.Run("should return zero tax category", func(t *testing.T) {
+		taxCode := xinvoice.FindTaxCode(tax.RateZero)
+
+		assert.Equal(t, xinvoice.ZeroRatedGoodsTax, taxCode)
+	})
+
+	t.Run("should return zero tax category", func(t *testing.T) {
+		taxCode := xinvoice.FindTaxCode(tax.RateExempt)
+
+		assert.Equal(t, xinvoice.TaxExempt, taxCode)
+	})
+}


### PR DESCRIPTION
## Pull Request Summary

We need to set tax categories in both lines and settlement. The categories are the same in both places so we want a single method to keep the logic consistent.

