### PR TITLE
Optional BuyerReference

### DIFF
--- a/agreement.go
+++ b/agreement.go
@@ -1,8 +1,6 @@
 package xinvoice
 
 import (
-	"fmt"
-
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/org"
 )
@@ -12,7 +10,7 @@ const SchemeIDEmail = "EM"
 
 // Agreement defines the structure of the ApplicableHeaderTradeAgreement of the CII standard
 type Agreement struct {
-	BuyerReference string  `xml:"ram:BuyerReference"`
+	BuyerReference string  `xml:"ram:BuyerReference,omitempty"`
 	Seller         *Seller `xml:"ram:SellerTradeParty"`
 	Buyer          *Buyer  `xml:"ram:BuyerTradeParty"`
 }
@@ -33,13 +31,10 @@ type URIUniversalCommunication struct {
 
 // NewAgreement creates the ApplicableHeaderTradeAgreement part of a EN 16931 compliant invoice
 func NewAgreement(inv *bill.Invoice) (*Agreement, error) {
-	ordering := inv.Ordering
-	if ordering == nil || ordering.Code == "" {
-		return nil, fmt.Errorf("ordering: code: missing")
-	}
+	agreement := new(Agreement)
 
-	agreement := &Agreement{
-		BuyerReference: ordering.Code,
+	if inv.Ordering != nil {
+		agreement.BuyerReference = inv.Ordering.Code
 	}
 
 	if supplier := inv.Supplier; supplier != nil {

--- a/test/data/invoice-without-buyers-tax-id.json
+++ b/test/data/invoice-without-buyers-tax-id.json
@@ -86,9 +86,6 @@
 				"total": "1800.00"
 			}
 		],
-		"ordering": {
-			"code": "XR-2024-3"
-		},
 		"payment": {
 				"terms": {
 						"detail": "lorem ipsum"

--- a/test/data/out/invoice-without-buyers-tax-id.xml
+++ b/test/data/out/invoice-without-buyers-tax-id.xml
@@ -43,7 +43,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>XR-2024-3</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One GmbH</ram:Name>
         <ram:DefinedTradeContact>


### PR DESCRIPTION
## Pull Request Summary

The schema seems to make the presence of `BuyerReference` optional. Since the GOBL ordering code it is filled with is not mandatory either, we add support for keeping it blank.

This PR also adds XSD schema check to the tests to prove that the schema allows this change.