### PR TITLE
Fixing bug on cmd

### DIFF
--- a/cmd/gobl.xinvoice/convert.go
+++ b/cmd/gobl.xinvoice/convert.go
@@ -20,7 +20,7 @@ func convert(o *rootOpts) *convertOpts {
 
 func (c *convertOpts) cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "convert [infile] [outfile]",
+		Use:   "convert <infile> <outfile>",
 		Short: "Convert a GOBL JSON into a XRechnung & Factur-X XML document",
 		RunE:  c.runE,
 	}
@@ -30,6 +30,10 @@ func (c *convertOpts) cmd() *cobra.Command {
 
 func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 	// ctx := commandContext(cmd)
+
+	if len(args) == 0 || len(args) > 2 {
+		return fmt.Errorf("expected one or two arguments, the command usage is `gobl.cfdi convert <infile> [outfile]`")
+	}
 
 	input, err := openInput(cmd, args)
 	if err != nil {


### PR DESCRIPTION
While doing the gobl.tin cmd functionality, I was taking this as reference and I found 1 bug. If you use the command convert without arguments, the cmd crashes. To fix this I added a condition that when the number of arguments is not 1 or 2 an error displays.


